### PR TITLE
Provide the sigul client configuration explicitly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,8 @@ jobs:
 
           # We aren't running under systemd here, so make up a fake CREDENTIALS_DIRECTORY
           mkdir -p /srv/siguldry/mock_credentials/
-          echo "my-signing-password" > /srv/siguldry/mock_credentials/sigul-signing-key-passphrase 
+          echo "my-signing-password" > /srv/siguldry/mock_credentials/sigul-signing-key-passphrase
+          cp ./devel/github/client.conf /srv/siguldry/mock_credentials/sigul-client-config
 
       - name: Integration tests
         run: RUNTIME_DIRECTORY=/run/pesign CREDENTIALS_DIRECTORY=/srv/siguldry/mock_credentials/ cargo test --all-features --workspace -- --nocapture

--- a/sigul-pesign-bridge/README.md
+++ b/sigul-pesign-bridge/README.md
@@ -28,5 +28,6 @@ podman compose up -d
 # the sigul_key_setup.sh script and must match.
 mkdir creds/
 echo "my-signing-password" > creds/sigul-signing-key-passphrase
+cp devel/local/client.conf creds/sigul-client-config
 CREDENTIALS_DIRECTORY=$(pwd)/creds/ cargo test
 ```


### PR DESCRIPTION
Switch to providing the sigul client configuration on the CLI when calling it and expect it to be provided via systemd credentials.

This is because the configuration file includes the NSS database passphrase so it would be best for it to be encrypted.