### PR TITLE
Fix up the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,75 @@
 
 Thanks for considering contributing to sigul-pesign-bridge, we really appreciate it!
 
+## Development Setup
+
+### Rust
+To build and test this project, you will need a relatively recent version of
+[Rust](https://www.rust-lang.org/). The current required version is documented
+in the `Cargo.toml` file for each crate.
+
+### System Dependencies
+
+A few dependencies from your distribution are also required. This is expected to run on Fedora or RHEL,
+although it may work elsewhere:
+
+```bash
+sudo dnf install pesign sigul sbsigntools
+```
+
+Additionally, the CI is easiest to run with containers for the Sigul bridge and server:
+
+```bash
+sudo dnf install podman podman-compose
+```
+
+### Integration Tests
+
+The integration tests use the Sigul server and Sigul bridge which can be tricky to set up. Fortunately,
+there's a container image (built from `devel/Containerfile.sigul`) to make things easier.
+
+#### One-time Setup
+
+There's some one-time setup required to allow you to run the integration tests outside
+a container. A CI container is available with the TLS certificates baked in (for
+**TESTING** *ONLY*). These include the Sigul client certificate. To extract them:
+
+```bash
+# This needs to be done whenever the CI container changes or the checked-in
+# sigul client configuration changes.
+mkdir ~/.sigul
+cp devel/local/client.conf ~/.sigul/client.conf
+podman pull quay.io/jeremycline/sigul-pesign-bridge-ci:latest && \
+    podman run --name sigul-key-extract quay.io/jeremycline/sigul-pesign-bridge-ci:latest && \
+    podman cp sigul-key-extract:/var/lib/sigul/ ~/.sigul && \
+    podman rm sigul-key-extract
+```
+
+We also need to set up a directory to match the layout of the secrets directory systemd
+provides the service:
+```bash
+# Set up a fake credentials directory like systemd. The signing password is set in
+# the sigul_key_setup.sh script and must match.
+mkdir creds/
+echo "my-signing-password" > creds/sigul-signing-key-passphrase
+cp devel/local/client.conf creds/sigul-client-config
+```
+
+#### Running tests
+
+Start the Sigul server and bridge by running the following from the repository root:
+
+```bash
+# Start the service and create signing keys. The signing keys
+# must be recreated whenever the compose is destroyed.
+podman compose up -d
+./devel/sigul_key_setup.sh
+```
+
+```bash
+SIGUL_PESIGN_BRIDGE_LOG=trace CREDENTIALS_DIRECTORY=$(pwd)/creds/ cargo test
+```
+
 ## Licensing
 
 Your commit messages must include a Signed-off-by tag with your name and e-mail

--- a/sigul-pesign-bridge/Cargo.toml
+++ b/sigul-pesign-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigul-pesign-bridge"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.79"
 edition = "2021"
 license = "MIT"

--- a/sigul-pesign-bridge/README.md
+++ b/sigul-pesign-bridge/README.md
@@ -1,33 +1,142 @@
 # sigul-pesign-bridge
+
 Drop-in replacement for pesign's daemon that bridges pesign-client requests to a Sigul server.
 
-# Integration test setup
+The service provides a Unix socket at, by default, `/run/pesign/socket`. `pesign-client` can be used to connect to this socket and request signatures for PE applications. Unlike `pesign`, this implementation forwards the request to a [sigul](https://pagure.io/sigul) signing server.
 
-This is a royal pain and could probably be easier. Steps for now:
+## Configuration
+
+Configuration is provided via a TOML file. The current configuration (or the default, if none is provided) can be seen with:
+```bash
+sigul-pesign-bridge config
+```
+
+The configuration format with in-line documentation:
+
+```toml
+# The systemd credentials ID of the Sigul client configuration.
+#
+# This configuration file includes the password to access the NSS database that contains the
+# client certificate used to authenticate with the Sigul server. As such, it is expected to
+# be provided by systemd's "LoadCredentialsEncrypted" option.
+#
+# To prepare the encrypted configuration::
+#
+#   # systemd-creds encrypt /secure/ramfs/sigul-client.conf /etc/sigul-pesign-bridge/sigul-client.conf
+#
+# This will produce an encrypted blob which will be decrypted by systemd at runtime.
+#  
+# # Example
+#
+# Suppose the systemd unit file contains the following::
+#  
+#     [Service]
+#     LoadCredentialsEncrypted=sigul-client-config:/etc/sigul-pesign-bridge/sigul-client.conf
+#
+# The credentials ID is "sigul-client-config". The decrypted file is provided to the service
+# by systemd using the path "$CREDENTIALS_PATH/sigul-client-config".
+sigul_client_config = "sigul-client-config"
+
+# The total length of time (in seconds) to wait for a signing request to complete.
+#
+# The service will retry requests to the Sigul server until it succeeds or
+# this timeout is reached, at which point it will signal to the pesign-client
+# that the request failed. This must be a non-zero value.
+request_timeout_secs = 600
+
+# A list of signing keys available for use.
+[[keys]]
+# The name of the key in Sigul.
+key_name = "signing-key"
+
+# The name of the certificate in Sigul.
+certificate_name = "codesigning"
+
+# The ID used in the systemd encrypted credential.
+passphrase_path = "sigul-signing-key-passphrase"
+
+# If set, the service will validate the PE has been signed with the given certificate
+# before returning the signed file to the client. This validation is done with the
+# "sbverify" application, which must be installed to use this option. This field is
+# optional.
+certificate_file = "/path/to/signing/certificate.pem"
+
+[[keys]]
+key_name = "other-signing-key"
+certificate_name = "other-codesigning"
+passphrase_path = "other-sigul-signing-key-passphrase"
+```
+
+## Running
+
+This document assumes the service is running under systemd using a unit file based off the one provided
+at `sigul-pesign-bridge/sigul-pesign-bridge.service`. Some set up is required as the expectation is all
+secrets are handled by systemd.
+
+### Configuration
+
+Place your TOML configuration at `/etc/sigul-pesign-bridge/config.toml`, which
+is the default set in the systemd unit file. Alternatively, adjust the unit file.
+
+### Secrets
+
+To start with, a few secrets need to be prepared. Refer to [systemd's
+credentials documentation](https://systemd.io/CREDENTIALS/) for details.
+
+To begin, the Sigul client configuration should be encrypted. The client
+configuration contains the password needed to access the Sigul client
+certificate in the NSS database:
 
 ```bash
-# Prerequisites: dnf install sigul pesign
-
-# This needs to be done whenever the CI container changes or the checked-in
-# sigul client configuration changes.
-mkdir ~/.sigul
-cp devel/local/client.conf ~/.sigul/client.conf
-podman pull quay.io/jeremycline/sigul-pesign-bridge-ci:latest && \
-    podman run --name sigul-key-extract quay.io/jeremycline/sigul-pesign-bridge-ci:latest && \
-    podman cp sigul-key-extract:/var/lib/sigul/ ~/.sigul && \
-    podman rm sigul-key-extract
-
-# Start the service and create signing keys. The signing keys
-# must be recreated whenever the compose is destroyed.
-podman compose up -d
-./devel/sigul_key_setup.sh
-
-# Finally we can run the tests.
-# 
-# Set up a fake credentials directory like systemd. The signing password is set in
-# the sigul_key_setup.sh script and must match.
-mkdir creds/
-echo "my-signing-password" > creds/sigul-signing-key-passphrase
-cp devel/local/client.conf creds/sigul-client-config
-CREDENTIALS_DIRECTORY=$(pwd)/creds/ cargo test
+# Assuming your sigul client configuration is prepared at /secure/ramfs/sigul-client-config
+systemd-creds encrypt /secure/ramfs/sigul-client-config /etc/sigul-pesign-bridge/sigul-client-config
 ```
+
+Next, for each signing key in Sigul, we should configure the passphrase needed to unlock it:
+
+```bash
+# This will prompt you for both passwords.
+systemd-ask-password -n | systemd-creds encrypt - /etc/sigul-pesign-bridge/sigul-signing-key-passphrase
+systemd-ask-password -n | systemd-creds encrypt - /etc/sigul-pesign-bridge/other-sigul-signing-key-passphrase
+```
+
+The service rejects passphrase files with newlines, so if you use
+`systemd-creds` directly for the passphrases, ensure they do not include
+trailing newlines.
+
+Finally, we must configure the systemd unit file to load the credentials. Either run
+
+```bash
+sudo systemctl edit sigul-pesign-bridge.service
+```
+
+or manually create `/etc/systemd/system/sigul-pesign-bridge.service.d/override.conf` and add an entry
+for each credential. For the example configuration above, this would look like:
+
+```ini
+[Service]
+LoadCredentialEncrypted=sigul-client-config:/etc/sigul-pesign-bridge/sigul-client-config
+LoadCredentialEncrypted=sigul-signing-key-passphrase:/etc/sigul-pesign-bridge/sigul-signing-key-passphrase
+LoadCredentialEncrypted=other-sigul-signing-key-passphrase:/etc/sigul-pesign-bridge/other-sigul-signing-key-passphrase
+```
+
+Finally, start the service:
+
+```
+sudo systemctl enable --now sigul-client-config.service
+```
+
+## Signing
+
+With the service running, you can now use it to sign PE files:
+
+```bash
+pesign-client --sign \
+    --token="signing-key" \
+    --certificate="codesigning" \
+    --infile=unsigned-application.efi \
+    --outfile=signed-application.efi
+```
+
+The default setup requires that the user executing pesign-client be in the
+`pesign` group.

--- a/sigul-pesign-bridge/sigul-pesign-bridge.service
+++ b/sigul-pesign-bridge/sigul-pesign-bridge.service
@@ -57,12 +57,12 @@ SystemCallFilter=@system-service
 # password-protected TLS certificate. The password can be provided
 # via systemd's Credentials features.
 #
+# For the NSS password, sigul uses getpass if it's not in the config file. We can set the password in
+# the configuration file and encrypt the entire thing.
+# $ systemd-creds encrypt /secure/ramfs/sigul-client-config /etc/sigul-pesign-bridge/sigul-client-config
+#LoadCredentialEncrypted=sigul-client-config:/etc/sigul-pesign-bridge/sigul-client-config
+
 # You can use the systemd-creds utility to set up the passphrase file.
 # For example:
 # $ systemd-ask-password -n | systemd-creds encrypt - /etc/sigul-pesign-bridge/sigul-signing-key-passphrase
-#
-# For the NSS password, sigul uses getpass if it's not in the config file. We can set the password in
-# the configuration file and encrypt the entire thing.
-# $ systemd-creds encrypt /secure/ramfs/sigul-client.conf /etc/sigul-pesign-bridge/sigul-client-conf
-LoadCredentialEncrypted=sigul-signing-key-passphrase:/etc/sigul-pesign-bridge/sigul-signing-key-passphrase
-LoadCredentialEncrypted=sigul-client-config:/etc/sigul-pesign-bridge/sigul-client-config
+#LoadCredentialEncrypted=sigul-signing-key-passphrase:/etc/sigul-pesign-bridge/sigul-signing-key-passphrase

--- a/sigul-pesign-bridge/src/cli.rs
+++ b/sigul-pesign-bridge/src/cli.rs
@@ -37,29 +37,31 @@ pub(crate) struct Cli {
 #[derive(clap::Subcommand, Debug)]
 pub(crate) enum Command {
     /// Run the service.
+    ///
+    /// The service provides a Unix socket at, by default, `/run/pesign/socket`.
+    /// `pesign-client` can be used to connect to this socket and request
+    /// signatures for PE applications. Unlike `pesign`, this implementation
+    /// forwards the request to a Sigul signing server.
     Listen {
         /// The service's runtime directory.
         ///
-        /// This is where the service socket is created, along with any
-        /// temporary files. The socket name will be `socket` under this
-        /// directory.
+        /// This is where the service socket is created, along with any temporary
+        /// files. The socket name will be `socket` under this directory.
         ///
         /// Anyone with access to the socket can get a PE application signed, so
         /// care should be taken to ensure this directory is not world-readable.
-        /// This directory should be read/writeable only to the service
-        /// owner/group. Temporary files created within this directory are
-        /// readable only to the owner, so users in the group can only acceess
-        /// the socket.
+        /// This directory should be read/writeable only to the service owner/group.
+        /// Temporary files created within this directory are readable only to the
+        /// owner, so users in the group can only acceess the socket.
         ///
-        /// When run under systemd, providing a `RuntimeDirectory=` directive
-        /// will set the environment variable automatically for you.
+        /// When run under systemd, providing a `RuntimeDirectory=` directive will
+        /// set the environment variable automatically for you.
         #[arg(long, short, env = "RUNTIME_DIRECTORY")]
         runtime_directory: PathBuf,
     },
     /// Print the current service configuration to standard output.
     ///
-    /// If no config file is provided, the defaults are printed. For
-    /// complete details on each configuration option, refer to the the
-    /// documentation.
+    /// If no config file is provided, the defaults are printed. For complete
+    /// details on each configuration option, refer to the the documentation.
     Config,
 }

--- a/sigul-pesign-bridge/src/main.rs
+++ b/sigul-pesign-bridge/src/main.rs
@@ -48,8 +48,11 @@ async fn main() -> Result<(), anyhow::Error> {
             service::listen(runtime_directory, config, halt_token)?.await?
         }
         cli::Command::Config => {
-            println!("{}", opts.config.unwrap_or_default());
-            Ok(())
+            let config = opts.config.unwrap_or_default();
+            println!("Current configuration:\n\n{}", config);
+            config.validate().inspect_err(|err|{
+                eprintln!("The configuration format is correct, but references files that are missing or invalid: {}", err);
+            })
         }
     }
 }


### PR DESCRIPTION
The readme should include helpful details for users, rather than a note on setting up integration tests.