### PR TITLE
Validate logging config and default to INFO level filter

### DIFF
--- a/sigul-pesign-bridge/src/cli.rs
+++ b/sigul-pesign-bridge/src/cli.rs
@@ -9,18 +9,14 @@ use crate::config::{self, Config};
 
 /// An alternative to the pesign daemon interface.
 ///
-/// Rather than signing the PE file, however, this application will act as a sigul client and
-/// forward it to a sigul signing server.
+/// The Unix socket this service offers can be used by pesign-client. Rather
+/// than signing the PE file, however, this application will act as a sigul
+/// client and forward it to a sigul signing server.
 ///
 /// Log configuration is provided using the "SIGUL_PESIGN_BRIDGE_LOG"
 /// environment variable with one or more comma-separated directives. In short,
 /// filters can be plain verbosity levels ("trace", "debug", "info", "warn",
-/// "error"), or more complex filtering at the span or event level.
-///
-/// The complete format is documented at
-/// https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives.
-///
-/// The Unix socket this service offers can be used by pesign-client.
+/// "error"), or more complex filtering at the model, span, or event level.
 #[derive(Parser, Debug)]
 #[command(version)]
 pub(crate) struct Cli {

--- a/sigul-pesign-bridge/src/config.rs
+++ b/sigul-pesign-bridge/src/config.rs
@@ -167,8 +167,8 @@ pub(crate) fn load(path: &str) -> anyhow::Result<Config> {
     tracing::info!(%path, "Read from configuration file");
     toml::from_str(&config)
         .inspect_err(|error| {
-            tracing::error!("Failed to parse configuration loaded from {path:?}:\n{error}");
-            tracing::info!("Example config file:\n\n{}", Config::default());
+            eprintln!("Failed to parse configuration loaded from {path:?}:\n{error}");
+            eprintln!("Example config file:\n\n{}", Config::default());
         })
         .context("configuration file is invalid")
 }


### PR DESCRIPTION
Rather than quietly ignoring incorrect logging directives, return an error immediately with a pointer to the format. Additionally, default to INFO-level logs as users will likely want to start at that level and reduce verbosity as necessary.