### PR TITLE
Improve documentation and include xtask for a manpage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [ 
     "sample-uefi",
     "sigul-pesign-bridge",
+    "xtask",
 ]

--- a/sigul-pesign-bridge/README.md
+++ b/sigul-pesign-bridge/README.md
@@ -18,23 +18,27 @@ The configuration format with in-line documentation:
 #
 # This configuration file includes the password to access the NSS database that contains the
 # client certificate used to authenticate with the Sigul server. As such, it is expected to
-# be provided by systemd's "LoadCredentialsEncrypted" option.
-#
-# To prepare the encrypted configuration::
-#
-#   # systemd-creds encrypt /secure/ramfs/sigul-client.conf /etc/sigul-pesign-bridge/sigul-client.conf
-#
-# This will produce an encrypted blob which will be decrypted by systemd at runtime.
-#  
+# be provided by systemd's "LoadCredentialEncrypted" option.
+# 
 # # Example
-#
-# Suppose the systemd unit file contains the following::
-#  
-#     [Service]
-#     LoadCredentialsEncrypted=sigul-client-config:/etc/sigul-pesign-bridge/sigul-client.conf
-#
-# The credentials ID is "sigul-client-config". The decrypted file is provided to the service
-# by systemd using the path "$CREDENTIALS_PATH/sigul-client-config".
+# 
+# To prepare the encrypted configuration:
+# 
+# ```bash
+# systemd-creds encrypt /secure/ramfs/sigul-client-config /etc/sigul-pesign-bridge/sigul-client-config
+# ```
+# 
+# This will produce an encrypted blob which will be decrypted by systemd at runtime. To provide
+# the decrypted secret to the service running under systemd, add the following override to the
+# service unit:
+# 
+# ```ini
+# [Service]
+# LoadCredentialEncrypted=sigul-client-config:/etc/sigul-pesign-bridge/sigul-client-config
+# ```
+# 
+# The credentials ID is `sigul-client-config`. The decrypted file is provided to the service
+# by systemd using the path `$CREDENTIALS_PATH/sigul-client-config`.
 sigul_client_config = "sigul-client-config"
 
 # The total length of time (in seconds) to wait for a signing request to complete.
@@ -72,11 +76,6 @@ passphrase_path = "other-sigul-signing-key-passphrase"
 This document assumes the service is running under systemd using a unit file based off the one provided
 at `sigul-pesign-bridge/sigul-pesign-bridge.service`. Some set up is required as the expectation is all
 secrets are handled by systemd.
-
-### Configuration
-
-Place your TOML configuration at `/etc/sigul-pesign-bridge/config.toml`, which
-is the default set in the systemd unit file. Alternatively, adjust the unit file.
 
 ### Secrets
 
@@ -120,9 +119,14 @@ LoadCredentialEncrypted=sigul-signing-key-passphrase:/etc/sigul-pesign-bridge/si
 LoadCredentialEncrypted=other-sigul-signing-key-passphrase:/etc/sigul-pesign-bridge/other-sigul-signing-key-passphrase
 ```
 
+Now that the secrets are prepared, place your TOML configuration at
+`/etc/sigul-pesign-bridge/config.toml`, which is the default set in the systemd
+unit file. Alternatively, adjust the unit file. Ensure the secret IDs set in the
+`override.conf` match those in the TOML configuration.
+
 Finally, start the service:
 
-```
+```bash
 sudo systemctl enable --now sigul-client-config.service
 ```
 

--- a/sigul-pesign-bridge/src/cli.rs
+++ b/sigul-pesign-bridge/src/cli.rs
@@ -19,7 +19,7 @@ use crate::config::{self, Config};
 /// "error"), or more complex filtering at the model, span, or event level.
 #[derive(Parser, Debug)]
 #[command(version)]
-pub(crate) struct Cli {
+pub struct Cli {
     /// Path to the configuration file.
     ///
     /// If no path is provided, the defaults are used. To view the service
@@ -31,7 +31,7 @@ pub(crate) struct Cli {
 }
 
 #[derive(clap::Subcommand, Debug)]
-pub(crate) enum Command {
+pub enum Command {
     /// Run the service.
     ///
     /// The service provides a Unix socket at, by default, `/run/pesign/socket`.

--- a/sigul-pesign-bridge/src/lib.rs
+++ b/sigul-pesign-bridge/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod cli;
+mod config;
+mod service;
+
+pub use config::{Config, Key};
+pub use service::listen;

--- a/sigul-pesign-bridge/src/lib.rs
+++ b/sigul-pesign-bridge/src/lib.rs
@@ -1,6 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+#![doc = include_str!("../README.md")]
+
+#[doc(hidden)]
 pub mod cli;
-mod config;
+pub mod config;
 mod service;
 
-pub use config::{Config, Key};
+#[doc(hidden)]
 pub use service::listen;

--- a/sigul-pesign-bridge/src/main.rs
+++ b/sigul-pesign-bridge/src/main.rs
@@ -8,9 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter};
 
-mod cli;
-mod config;
-mod service;
+use sigul_pesign_bridge::{cli, listen};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), anyhow::Error> {
@@ -56,7 +54,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 "configuration format is correct, but references files that are missing or invalid",
             )?;
 
-            service::listen(runtime_directory, config, halt_token)?.await?
+            listen(runtime_directory, config, halt_token)?.await?
         }
         cli::Command::Config => {
             let config = opts.config.unwrap_or_default();

--- a/sigul-pesign-bridge/src/service.rs
+++ b/sigul-pesign-bridge/src/service.rs
@@ -235,8 +235,9 @@ impl TryFrom<u32> for Command {
 ///
 /// Pending requests will be allowed to complete before the task
 /// completes.
+#[doc(hidden)]
 #[instrument(err, skip_all)]
-pub(crate) fn listen(
+pub fn listen(
     runtime_directory: PathBuf,
     config: Config,
     halt_token: CancellationToken,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[dependencies.anyhow]
+version = "1.0.47"
+
+[dependencies.clap_mangen]
+version = "0.2"
+
+[dependencies.clap]
+version = "4"
+
+[dependencies.sigul-pesign-bridge]
+path = "../sigul-pesign-bridge"
+version = "0.1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+use std::{env, path::PathBuf};
+
+use anyhow::anyhow;
+use clap::CommandFactory;
+
+#[derive(Debug)]
+enum Task {
+    Manual,
+}
+
+impl TryFrom<&str> for Task {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "manual" => Ok(Task::Manual),
+            _ => Err(anyhow!("Unknown task")),
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let task: Task = env::args()
+        .nth(1)
+        .ok_or(anyhow!("Must provide a task"))?
+        .as_str()
+        .try_into()?;
+    match task {
+        Task::Manual => generate_manual(),
+    }
+}
+
+fn generate_manual() -> anyhow::Result<()> {
+    let outdir = PathBuf::from(env::var_os("OUT_DIR").ok_or(anyhow!("Must set OUT_DIR"))?);
+    let command = sigul_pesign_bridge::cli::Cli::command();
+    let manual = clap_mangen::Man::new(command);
+    manual.generate_to(outdir)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a library stub so the documentation on the configuration structure is rendered in the rustdocs. There's also a task to create a manual page which can be created with `OUT_DIR=target/docs/ cargo xtask manual`.