### PR TITLE
Add /dev/tpmrm0 as an allowed device to the systemd unit

### DIFF
--- a/sigul-pesign-bridge/sigul-pesign-bridge.service
+++ b/sigul-pesign-bridge/sigul-pesign-bridge.service
@@ -32,6 +32,11 @@ LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=true
+# Credentials may require the TPM to decrypt.
+#
+# Refer to https://github.com/systemd/systemd/issues/35959 as this directive
+# might be removable in the future.
+DeviceAllow=/dev/tpmrm0
 PrivateTmp=true
 ProtectClock=true
 ProtectControlGroups=true


### PR DESCRIPTION
With the switch to `ImportCredential=` in #15, systemd does not currently implicitly include the TPM as an allowed device[0].

Although the documentation seems to imply `PrivateDevices=true` and `DeviceAllow=` are mutually exclusive, it seems to accept both and does the right thing.

[0] https://github.com/systemd/systemd/issues/35959