### PR TITLE
Adjust expected environment variables to be explicit CLI args

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,6 +136,9 @@ jobs:
           mkdir -p ~/.sigul
           cp devel/github/client.conf ~/.sigul/client.conf
           cp -r /var/lib/sigul ~/.sigul/sigul
+          # GitHub actions occasionally hangs here; I've not seen it locally and my theory
+          # is sigul takes a bit of time to come up and doesn't do retries well at all.
+          sleep 5
           bash ./devel/sigul_key_setup.sh
 
           # More hackiness; copy the test PE and signing certificates to the location

--- a/sigul-pesign-bridge/src/cli.rs
+++ b/sigul-pesign-bridge/src/cli.rs
@@ -26,6 +26,18 @@ pub struct Cli {
     /// defaults, run the `config` subcommand.
     #[arg(long, short, env = "SIGUL_PESIGN_BRIDGE_CONFIG", value_parser = config::load)]
     pub config: Option<Config>,
+    /// A set of one or more comma-separated directives to filter logs.
+    ///
+    /// The general format is "target_name[span_name{field=value}]=level" where level is
+    /// one of TRACE, DEBUG, INFO, WARN, ERROR.
+    ///
+    /// Details: https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    #[arg(
+        long,
+        env = "SIGUL_PESIGN_BRIDGE_LOG",
+        default_value = "WARN,sigul_pesign_bridge=INFO"
+    )]
+    pub log_filter: String,
     #[command(subcommand)]
     pub command: Command,
 }

--- a/sigul-pesign-bridge/src/cli.rs
+++ b/sigul-pesign-bridge/src/cli.rs
@@ -64,8 +64,20 @@ pub enum Command {
         ///
         /// When run under systemd, providing a `RuntimeDirectory=` directive will
         /// set the environment variable automatically for you.
-        #[arg(long, short, env = "RUNTIME_DIRECTORY")]
+        #[arg(long, env = "RUNTIME_DIRECTORY")]
         runtime_directory: PathBuf,
+
+        /// The directory containing the service's secrets.
+        ///
+        /// The `sigul_client_config` setting in the configuration file is expected
+        /// to be relative to this directory, as are the `passphrase_path` settings
+        /// for each configured `key`.
+        ///
+        /// When run under systemd, providing a `ImportCredential=`,
+        /// `LoadCredentialEncrypted=`, or `LoadCredential=` directive will
+        /// set the environment variable automatically for you.
+        #[arg(long, env = "CREDENTIALS_DIRECTORY")]
+        credentials_directory: PathBuf,
     },
     /// Print the current service configuration to standard output.
     ///

--- a/sigul-pesign-bridge/src/lib.rs
+++ b/sigul-pesign-bridge/src/lib.rs
@@ -9,5 +9,43 @@ pub mod config;
 pub(crate) mod pesign;
 mod service;
 
+use std::path::PathBuf;
+
 #[doc(hidden)]
 pub use service::listen;
+
+/// Unifying structure for the CLI options and configuration file.
+#[derive(Debug, Clone)]
+#[doc(hidden)]
+pub struct Context {
+    pub(crate) runtime_directory: PathBuf,
+    pub(crate) credentials_directory: PathBuf,
+    pub(crate) config: config::Config,
+}
+
+impl Context {
+    pub fn new(
+        config: config::Config,
+        runtime_directory: PathBuf,
+        credentials_directory: PathBuf,
+    ) -> anyhow::Result<Self> {
+        // if multiple runtime directories were provided, we don't know which to use so panic for now.
+        if runtime_directory
+            .to_str()
+            .ok_or(anyhow::anyhow!(
+                "runtime_directory must be valid unicode characters"
+            ))?
+            .contains(':')
+        {
+            return Err(anyhow::anyhow!(
+                "Multiple RuntimeDirectories are not supported"
+            ));
+        }
+
+        Ok(Self {
+            runtime_directory,
+            credentials_directory,
+            config,
+        })
+    }
+}

--- a/sigul-pesign-bridge/tests/config.rs
+++ b/sigul-pesign-bridge/tests/config.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+use std::process::{Command, Stdio};
+
+use anyhow::Result;
+use assert_cmd::cargo::CommandCargoExt;
+
+#[test]
+fn config_with_default_works() -> Result<()> {
+    let mut command = Command::cargo_bin("sigul-pesign-bridge")?;
+    let output = command
+        .arg("config")
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .output()?;
+    let logs = String::from_utf8_lossy(&output.stdout);
+    println!("cli_stdout: {logs}");
+    assert!(output.status.success());
+    assert!(logs.contains(
+        "Current configuration:
+
+sigul_client_config = \"sigul-client-config\"
+request_timeout_secs = 900
+
+[[keys]]
+key_name = \"signing-key\"
+certificate_name = \"codesigning\"
+passphrase_path = \"sigul-signing-key-passphrase\"
+"
+    ));
+
+    Ok(())
+}


### PR DESCRIPTION
The server would look for two mostly undocumented environment variables: `SIGUL_PESIGN_BRIDGE_LOG` and `CREDENTIALS_DIRECTORY`. Adjust things so they are both prompted for by the CLI and used in the service.